### PR TITLE
jekyll working on macOS

### DIFF
--- a/bin/run_jekyll.sh
+++ b/bin/run_jekyll.sh
@@ -1,0 +1,2 @@
+bundle exec jekyll serve --incremental
+#bundle exec jekyll serve

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -3,3 +3,6 @@ source "https://rubygems.org" # source "https://gems.ruby-china.com"
 gemspec
 
 gem "github-pages", group: :jekyll_plugins
+
+# webrick is needed for ruby 3 (major version bump for latest version available on macOS using brew)
+gem "webrick", "~> 1.7"

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,3 +10,11 @@ This support documentation is for those users who need to use OnTheDay.net with 
 ## Contents
 These pages contain process descriptions, procedures, and troubleshooting information. 
 
+---
+### Temporary dev notes
+
+- ```JEKYLL_GITHUB_TOKEN``` and ```SSL_CERT_FILE``` appear to slightly speed up the first build, 
+  but make no difference in subsequent updates -
+  [see here](https://knightcodes.com/miscellaneous/2016/09/13/fix-github-metadata-error.html)
+-  Running with ```--incremental``` doesn't appear to affect the first build, but does speed up 
+   subsequent updates


### PR DESCRIPTION
JEKYLL_GITHUB_TOKEN and SSL_CERT_FILE appear to slightly speed up the first build, but make no difference in subsequent updates - https://knightcodes.com/miscellaneous/2016/09/13/fix-github-metadata-error.html

Running with --incremental doesn't appear to affect the first build, but does speed up subsequent updates